### PR TITLE
fix: add cfn condition for auto-configure resources

### DIFF
--- a/test/sonatype-nexus3.test.ts
+++ b/test/sonatype-nexus3.test.ts
@@ -300,6 +300,7 @@ describe('Nexus OSS stack', () => {
       DependsOn: [
         'NexusClusterchartNexus37BADE970',
       ],
+      Condition: 'EKSV119',
     }, ResourcePart.CompleteDefinition);
   });
 


### PR DESCRIPTION
as workaround when provisioning EKS v1.19 with auto-configure feat

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.