### PR TITLE
feat: bump aws load balancer controller, nexus chart adapting to network api v1

### DIFF
--- a/src/lib/sonatype-nexus3-stack.ts
+++ b/src/lib/sonatype-nexus3-stack.ts
@@ -235,10 +235,9 @@ export class SonatypeNexus3Stack extends cdk.Stack {
         allowedValues: [
           '1.22',
           '1.21',
-          '1.20',
-          '1.19'
+          '1.20'
         ],
-        default: '1.20',
+        default: '1.22',
         description: 'The version of Kubernetes.',
       });
 


### PR DESCRIPTION
*Issue #, if available:*

closes #143 
closes #144 

*Description of changes:*
- [x] Remove EOL EKS version 1.18-1.19
- [x] Upgrade ALB ingress controller to 2.4.1
- [x] Upgrade Nexus chart to 5.4.0
- [x] Modify ALB rules format to adapt to networking API v1
- [x] unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.