### PR TITLE
feat: bump aws load balancer controller, nexus chart adapting to network api v1

### DIFF
--- a/.github/workflows/lambda-integration-test.yml
+++ b/.github/workflows/lambda-integration-test.yml
@@ -55,7 +55,7 @@ jobs:
           pytest -m integration
     services:
       nexus:
-        image: 'quay.io/travelaudience/docker-nexus:3.27.0'
+        image: 'quay.io/travelaudience/docker-nexus:3.37.3-02'
         ports:
           - '8081:8081'
         options: >-

--- a/src/lib/sonatype-nexus3-stack.ts
+++ b/src/lib/sonatype-nexus3-stack.ts
@@ -235,7 +235,7 @@ export class SonatypeNexus3Stack extends cdk.Stack {
         allowedValues: [
           '1.22',
           '1.21',
-          '1.20'
+          '1.20',
         ],
         default: '1.20',
         description: 'The version of Kubernetes.',
@@ -565,7 +565,7 @@ export class SonatypeNexus3Stack extends cdk.Stack {
                   name: `${nexus3ChartName}-sonatype-nexus`,
 		  port: {
 		    number: nexusPort,
-		},
+	       },
                },
               },
             },
@@ -590,10 +590,10 @@ export class SonatypeNexus3Stack extends cdk.Stack {
               path: '/',
 	      pathType: 'Prefix',
               backend: {
-                service: {
+                service :{
                   name: 'ssl-redirect',
                   port: {
-		    number:  'use-annotation',
+		    number: 'use-annotation',
                 },
               },
             },

--- a/src/lib/sonatype-nexus3-stack.ts
+++ b/src/lib/sonatype-nexus3-stack.ts
@@ -235,8 +235,7 @@ export class SonatypeNexus3Stack extends cdk.Stack {
         allowedValues: [
           '1.22',
           '1.21',
-          '1.20',
-          '1.19'
+          '1.20'
         ],
         default: '1.20',
         description: 'The version of Kubernetes.',

--- a/src/lib/sonatype-nexus3-stack.ts
+++ b/src/lib/sonatype-nexus3-stack.ts
@@ -590,24 +590,24 @@ export class SonatypeNexus3Stack extends cdk.Stack {
               path: '/',
 	      pathType: 'Prefix',
               backend: {
-                service :{
+                service: {
                   name: 'ssl-redirect',
                   port: {
 		    number: 'use-annotation',
-                },
+		   },
+		 },
               },
             },
-	   },
             {
               path: '/',
 	      pathType: 'Prefix',
               backend: {
-                service :{
+                service: {
                   name: `${nexus3ChartName}-sonatype-nexus`,
                   port: {
-		    number:  nexusPort,
+		    number: nexusPort,
            	 },
-	       },
+	        },
               },
             },
           ],

--- a/src/lib/sonatype-nexus3-stack.ts
+++ b/src/lib/sonatype-nexus3-stack.ts
@@ -566,7 +566,7 @@ export class SonatypeNexus3Stack extends cdk.Stack {
 		  port: {
 		    number: nexusPort,
 	       },
-               },
+                },
               },
             },
           ],

--- a/test/sonatype-nexus3.test.ts
+++ b/test/sonatype-nexus3.test.ts
@@ -130,7 +130,7 @@ describe('Nexus OSS stack', () => {
       },
       Release: 'nexus3',
       Chart: 'sonatype-nexus',
-      Version: '5.2.1',
+      Version: '5.4.0',
       Namespace: 'default',
       Repository: {
         'Fn::FindInMap': [
@@ -371,7 +371,7 @@ describe('Nexus OSS stack', () => {
     expect(stack).toHaveResourceLike('Custom::AWSCDK-EKS-HelmChart', {
       Release: 'aws-load-balancer-controller',
       Chart: 'aws-load-balancer-controller',
-      Version: '1.2.7',
+      Version: '1.4.1',
       Repository: {
         'Fn::FindInMap': [
           'PartitionMapping',

--- a/test/sonatype-nexus3.test.ts
+++ b/test/sonatype-nexus3.test.ts
@@ -104,7 +104,7 @@ describe('Nexus OSS stack', () => {
                 'nexus',
               ],
             },
-            '","resources":{"requests":{"memory":"4800Mi"}},"livenessProbe":{"path":"/"}},"nexusProxy":{"enabled":false},"persistence":{"enabled":true,"storageClass":"efs-sc","accessMode":"ReadWriteMany"},"nexusBackup":{"enabled":false,"persistence":{"enabled":false}},"nexusCloudiam":{"enabled":false,"persistence":{"enabled":false}},"ingress":{"enabled":true,"path":"/*","annotations":{"alb.ingress.kubernetes.io/backend-protocol":"HTTP","alb.ingress.kubernetes.io/healthcheck-path":"/","alb.ingress.kubernetes.io/healthcheck-port":8081,"alb.ingress.kubernetes.io/listen-ports":"[{\"HTTP\": 80}]","alb.ingress.kubernetes.io/scheme":"internet-facing","alb.ingress.kubernetes.io/inbound-cidrs":"0.0.0.0/0","alb.ingress.kubernetes.io/auth-type":"none","alb.ingress.kubernetes.io/target-type":"ip","kubernetes.io/ingress.class":"alb","alb.ingress.kubernetes.io/tags":"app=nexus3","alb.ingress.kubernetes.io/subnets":"',
+            '","resources":{"requests":{"memory":"4800Mi"}},"livenessProbe":{"path":"/"}},"nexusProxy":{"enabled":false},"persistence":{"enabled":true,"storageClass":"efs-sc","accessMode":"ReadWriteMany"},"nexusBackup":{"enabled":false,"persistence":{"enabled":false}},"nexusCloudiam":{"enabled":false,"persistence":{"enabled":false}},"ingress":{"enabled":true,"path":"/*","annotations":{"alb.ingress.kubernetes.io/backend-protocol":"HTTP","alb.ingress.kubernetes.io/healthcheck-path":"/","alb.ingress.kubernetes.io/healthcheck-port":8081,"alb.ingress.kubernetes.io/listen-ports":"[{\\"HTTP\\": 80}, {\\"HTTPS\\": 443}]","alb.ingress.kubernetes.io/scheme":"internet-facing","alb.ingress.kubernetes.io/inbound-cidrs":"0.0.0.0/0","alb.ingress.kubernetes.io/auth-type":"none","alb.ingress.kubernetes.io/target-type":"ip","kubernetes.io/ingress.class":"alb","alb.ingress.kubernetes.io/tags":"app=nexus3","alb.ingress.kubernetes.io/subnets":"',
             {
               Ref: 'NexusOSSVpcPublicSubnet1SubnetE287B3FC',
             },
@@ -116,8 +116,15 @@ describe('Nexus OSS stack', () => {
             {
               Ref: 'LogBucketCC3B17E8',
             },
-            ',access_logs.s3.prefix=albAccessLog"},"tls":{"enabled":false},"rules":[{"http":{"paths":[{"path":"/","pathType":"Prefix","backend":{"service":{"name":"nexus3-sonatype-nexus","port":{"number":8081}}}}]}}]},"serviceAccount":{"create":false}}'
-          
+            ',access_logs.s3.prefix=albAccessLog","alb.ingress.kubernetes.io/certificate-arn":"',
+            {
+              Ref: 'SSLCertificate2E93C565',
+            },
+            '","alb.ingress.kubernetes.io/ssl-policy":"ELBSecurityPolicy-TLS-1-2-Ext-2018-06","alb.ingress.kubernetes.io/actions.ssl-redirect":"{\\"Type\\": \\"redirect\\", \\"RedirectConfig\\": { \\"Protocol\\": \\"HTTPS\\", \\"Port\\": \\"443\\", \\"StatusCode\\": \\"HTTP_301\\"}}"},"tls":{"enabled":false},"rules":[{"host":"',
+            {
+              Ref: 'DomainName',
+            },
+	          '","http":{"paths":[{"path":"/","pathType":"Prefix","backend":{"service":{"name":"ssl-redirect","port":{"number":"use-annotation"}}}},{"path":"/","pathType":"Prefix","backend":{"service":{"name":"nexus3-sonatype-nexus","port":{"number":8081}}}}]}},{"http":{"paths":[{"path":"/","pathType":"Prefix","backend":{"service":{"name":"nexus3-sonatype-nexus","port":{"number":8081}}}}]}}]},"serviceAccount":{"create":false}}',
           ],
         ],
       },
@@ -272,7 +279,7 @@ describe('Nexus OSS stack', () => {
                 'nexus',
               ],
             },
-            '","resources":{"requests":{"memory":"4800Mi"}},"livenessProbe":{"path":"/"}},"nexusProxy":{"enabled":false},"persistence":{"enabled":true,"storageClass":"efs-sc","accessMode":"ReadWriteMany"},"nexusBackup":{"enabled":false,"persistence":{"enabled":false}},"nexusCloudiam":{"enabled":false,"persistence":{"enabled":false}},"ingress":{"enabled":true,"path":"/*","annotations":{"alb.ingress.kubernetes.io/backend-protocol":"HTTP","alb.ingress.kubernetes.io/healthcheck-path":"/","alb.ingress.kubernetes.io/healthcheck-port":8081,"alb.ingress.kubernetes.io/listen-ports":"[{\"HTTP\": 80}]","alb.ingress.kubernetes.io/scheme":"internet-facing","alb.ingress.kubernetes.io/inbound-cidrs":"0.0.0.0/0","alb.ingress.kubernetes.io/auth-type":"none","alb.ingress.kubernetes.io/target-type":"ip","kubernetes.io/ingress.class":"alb","alb.ingress.kubernetes.io/tags":"app=nexus3","alb.ingress.kubernetes.io/subnets":"',
+            '","resources":{"requests":{"memory":"4800Mi"}},"livenessProbe":{"path":"/"}},"nexusProxy":{"enabled":false},"persistence":{"enabled":true,"storageClass":"efs-sc","accessMode":"ReadWriteMany"},"nexusBackup":{"enabled":false,"persistence":{"enabled":false}},"nexusCloudiam":{"enabled":false,"persistence":{"enabled":false}},"ingress":{"enabled":true,"path":"/*","annotations":{"alb.ingress.kubernetes.io/backend-protocol":"HTTP","alb.ingress.kubernetes.io/healthcheck-path":"/","alb.ingress.kubernetes.io/healthcheck-port":8081,"alb.ingress.kubernetes.io/listen-ports":"[{\\"HTTP\\": 80}, {\\"HTTPS\\": 443}]","alb.ingress.kubernetes.io/scheme":"internet-facing","alb.ingress.kubernetes.io/inbound-cidrs":"0.0.0.0/0","alb.ingress.kubernetes.io/auth-type":"none","alb.ingress.kubernetes.io/target-type":"ip","kubernetes.io/ingress.class":"alb","alb.ingress.kubernetes.io/tags":"app=nexus3","alb.ingress.kubernetes.io/subnets":"',
             {
               Ref: 'NexusOSSVpcPublicSubnet1SubnetE287B3FC',
             },
@@ -284,7 +291,15 @@ describe('Nexus OSS stack', () => {
             {
               Ref: 'LogBucketCC3B17E8',
             },
-            ',access_logs.s3.prefix=albAccessLog"},"tls":{"enabled":false},"rules":[{"http":{"paths":[{"path":"/","pathType":"Prefix","backend":{"service":{"name":"nexus3-sonatype-nexus","port":{"number":8081}}}}]}}]},"serviceAccount":{"create":false}}'
+            ',access_logs.s3.prefix=albAccessLog","alb.ingress.kubernetes.io/certificate-arn":"',
+            {
+              Ref: 'SSLCertificate2E93C565',
+            },
+            '","alb.ingress.kubernetes.io/ssl-policy":"ELBSecurityPolicy-TLS-1-2-Ext-2018-06","alb.ingress.kubernetes.io/actions.ssl-redirect":"{\\"Type\\": \\"redirect\\", \\"RedirectConfig\\": { \\"Protocol\\": \\"HTTPS\\", \\"Port\\": \\"443\\", \\"StatusCode\\": \\"HTTP_301\\"}}"},"tls":{"enabled":false},"rules":[{"host":"',
+            {
+              Ref: 'DomainName',
+            },
+            '","http":{"paths":[{"path":"/","pathType":"Prefix","backend":{"service":{"name":"ssl-redirect","port":{"number":"use-annotation"}}}},{"path":"/","pathType":"Prefix","backend":{"service":{"name":"nexus3-sonatype-nexus","port":{"number":8081}}}}]}},{"http":{"paths":[{"path":"/","pathType":"Prefix","backend":{"service":{"name":"nexus3-sonatype-nexus","port":{"number":8081}}}}]}}]},"serviceAccount":{"create":false},"config":{"enabled":true,"data":{"nexus.properties":"nexus.scripts.allowCreation=true"}},"deployment":{"additionalVolumeMounts":[{"mountPath":"/nexus-data/etc/nexus.properties","subPath":"nexus.properties","name":"sonatype-nexus-conf"}]}}',
           ],
         ],
       },
@@ -666,7 +681,7 @@ describe('Nexus OSS stack', () => {
             {
               Ref: 'LogBucketCC3B17E8',
             },
-            ',access_logs.s3.prefix=albAccessLog"},"tls":{"enabled":false},"rules":[{"http":{"paths":[{"path":"/*","backend":{"serviceName":"nexus3-sonatype-nexus","servicePort":8081}}]}}]},"serviceAccount":{"create":false}}',
+            ',access_logs.s3.prefix=albAccessLog"},"tls":{"enabled":false},"rules":[{"http":{"paths":[{"path":"/","pathType":"Prefix","backend":{"service":{"name":"nexus3-sonatype-nexus","port":{"number":8081}}}}]}}]},"serviceAccount":{"create":false}}',
           ],
         ],
       },

--- a/test/sonatype-nexus3.test.ts
+++ b/test/sonatype-nexus3.test.ts
@@ -104,7 +104,7 @@ describe('Nexus OSS stack', () => {
                 'nexus',
               ],
             },
-            '","resources":{"requests":{"memory":"4800Mi"}},"livenessProbe":{"path":"/"}},"nexusProxy":{"enabled":false},"persistence":{"enabled":true,"storageClass":"efs-sc","accessMode":"ReadWriteMany"},"nexusBackup":{"enabled":false,"persistence":{"enabled":false}},"nexusCloudiam":{"enabled":false,"persistence":{"enabled":false}},"ingress":{"enabled":true,"path":"/*","annotations":{"alb.ingress.kubernetes.io/backend-protocol":"HTTP","alb.ingress.kubernetes.io/healthcheck-path":"/","alb.ingress.kubernetes.io/healthcheck-port":8081,"alb.ingress.kubernetes.io/listen-ports":"[{\\"HTTP\\": 80}, {\\"HTTPS\\": 443}]","alb.ingress.kubernetes.io/scheme":"internet-facing","alb.ingress.kubernetes.io/inbound-cidrs":"0.0.0.0/0","alb.ingress.kubernetes.io/auth-type":"none","alb.ingress.kubernetes.io/target-type":"ip","kubernetes.io/ingress.class":"alb","alb.ingress.kubernetes.io/tags":"app=nexus3","alb.ingress.kubernetes.io/subnets":"',
+            '","resources":{"requests":{"memory":"4800Mi"}},"livenessProbe":{"path":"/"}},"nexusProxy":{"enabled":false},"persistence":{"enabled":true,"storageClass":"efs-sc","accessMode":"ReadWriteMany"},"nexusBackup":{"enabled":false,"persistence":{"enabled":false}},"nexusCloudiam":{"enabled":false,"persistence":{"enabled":false}},"ingress":{"enabled":true,"path":"/*","annotations":{"alb.ingress.kubernetes.io/backend-protocol":"HTTP","alb.ingress.kubernetes.io/healthcheck-path":"/","alb.ingress.kubernetes.io/healthcheck-port":8081,"alb.ingress.kubernetes.io/listen-ports":"[{\"HTTP\": 80}]","alb.ingress.kubernetes.io/scheme":"internet-facing","alb.ingress.kubernetes.io/inbound-cidrs":"0.0.0.0/0","alb.ingress.kubernetes.io/auth-type":"none","alb.ingress.kubernetes.io/target-type":"ip","kubernetes.io/ingress.class":"alb","alb.ingress.kubernetes.io/tags":"app=nexus3","alb.ingress.kubernetes.io/subnets":"',
             {
               Ref: 'NexusOSSVpcPublicSubnet1SubnetE287B3FC',
             },
@@ -116,15 +116,8 @@ describe('Nexus OSS stack', () => {
             {
               Ref: 'LogBucketCC3B17E8',
             },
-            ',access_logs.s3.prefix=albAccessLog","alb.ingress.kubernetes.io/certificate-arn":"',
-            {
-              Ref: 'SSLCertificate2E93C565',
-            },
-            '","alb.ingress.kubernetes.io/ssl-policy":"ELBSecurityPolicy-TLS-1-2-Ext-2018-06","alb.ingress.kubernetes.io/actions.ssl-redirect":"{\\"Type\\": \\"redirect\\", \\"RedirectConfig\\": { \\"Protocol\\": \\"HTTPS\\", \\"Port\\": \\"443\\", \\"StatusCode\\": \\"HTTP_301\\"}}"},"tls":{"enabled":false},"rules":[{"host":"',
-            {
-              Ref: 'DomainName',
-            },
-            '","http":{"paths":[{"path":"/*","backend":{"serviceName":"ssl-redirect","servicePort":"use-annotation"}},{"path":"/*","backend":{"serviceName":"nexus3-sonatype-nexus","servicePort":8081}}]}},{"http":{"paths":[{"path":"/*","backend":{"serviceName":"nexus3-sonatype-nexus","servicePort":8081}}]}}]},"serviceAccount":{"create":false}}',
+            ',access_logs.s3.prefix=albAccessLog"},"tls":{"enabled":false},"rules":[{"http":{"paths":[{"path":"/","pathType":"Prefix","backend":{"service":{"name":"nexus3-sonatype-nexus","port":{"number":8081}}}}]}}]},"serviceAccount":{"create":false}}'
+          
           ],
         ],
       },
@@ -279,7 +272,7 @@ describe('Nexus OSS stack', () => {
                 'nexus',
               ],
             },
-            '","resources":{"requests":{"memory":"4800Mi"}},"livenessProbe":{"path":"/"}},"nexusProxy":{"enabled":false},"persistence":{"enabled":true,"storageClass":"efs-sc","accessMode":"ReadWriteMany"},"nexusBackup":{"enabled":false,"persistence":{"enabled":false}},"nexusCloudiam":{"enabled":false,"persistence":{"enabled":false}},"ingress":{"enabled":true,"path":"/*","annotations":{"alb.ingress.kubernetes.io/backend-protocol":"HTTP","alb.ingress.kubernetes.io/healthcheck-path":"/","alb.ingress.kubernetes.io/healthcheck-port":8081,"alb.ingress.kubernetes.io/listen-ports":"[{\\"HTTP\\": 80}, {\\"HTTPS\\": 443}]","alb.ingress.kubernetes.io/scheme":"internet-facing","alb.ingress.kubernetes.io/inbound-cidrs":"0.0.0.0/0","alb.ingress.kubernetes.io/auth-type":"none","alb.ingress.kubernetes.io/target-type":"ip","kubernetes.io/ingress.class":"alb","alb.ingress.kubernetes.io/tags":"app=nexus3","alb.ingress.kubernetes.io/subnets":"',
+            '","resources":{"requests":{"memory":"4800Mi"}},"livenessProbe":{"path":"/"}},"nexusProxy":{"enabled":false},"persistence":{"enabled":true,"storageClass":"efs-sc","accessMode":"ReadWriteMany"},"nexusBackup":{"enabled":false,"persistence":{"enabled":false}},"nexusCloudiam":{"enabled":false,"persistence":{"enabled":false}},"ingress":{"enabled":true,"path":"/*","annotations":{"alb.ingress.kubernetes.io/backend-protocol":"HTTP","alb.ingress.kubernetes.io/healthcheck-path":"/","alb.ingress.kubernetes.io/healthcheck-port":8081,"alb.ingress.kubernetes.io/listen-ports":"[{\"HTTP\": 80}]","alb.ingress.kubernetes.io/scheme":"internet-facing","alb.ingress.kubernetes.io/inbound-cidrs":"0.0.0.0/0","alb.ingress.kubernetes.io/auth-type":"none","alb.ingress.kubernetes.io/target-type":"ip","kubernetes.io/ingress.class":"alb","alb.ingress.kubernetes.io/tags":"app=nexus3","alb.ingress.kubernetes.io/subnets":"',
             {
               Ref: 'NexusOSSVpcPublicSubnet1SubnetE287B3FC',
             },
@@ -291,15 +284,7 @@ describe('Nexus OSS stack', () => {
             {
               Ref: 'LogBucketCC3B17E8',
             },
-            ',access_logs.s3.prefix=albAccessLog","alb.ingress.kubernetes.io/certificate-arn":"',
-            {
-              Ref: 'SSLCertificate2E93C565',
-            },
-            '","alb.ingress.kubernetes.io/ssl-policy":"ELBSecurityPolicy-TLS-1-2-Ext-2018-06","alb.ingress.kubernetes.io/actions.ssl-redirect":"{\\"Type\\": \\"redirect\\", \\"RedirectConfig\\": { \\"Protocol\\": \\"HTTPS\\", \\"Port\\": \\"443\\", \\"StatusCode\\": \\"HTTP_301\\"}}"},"tls":{"enabled":false},"rules":[{"host":"',
-            {
-              Ref: 'DomainName',
-            },
-            '","http":{"paths":[{"path":"/*","backend":{"serviceName":"ssl-redirect","servicePort":"use-annotation"}},{"path":"/*","backend":{"serviceName":"nexus3-sonatype-nexus","servicePort":8081}}]}},{"http":{"paths":[{"path":"/*","backend":{"serviceName":"nexus3-sonatype-nexus","servicePort":8081}}]}}]},"serviceAccount":{"create":false},"config":{"enabled":true,"data":{"nexus.properties":"nexus.scripts.allowCreation=true"}},"deployment":{"additionalVolumeMounts":[{"mountPath":"/nexus-data/etc/nexus.properties","subPath":"nexus.properties","name":"sonatype-nexus-conf"}]}}',
+            ',access_logs.s3.prefix=albAccessLog"},"tls":{"enabled":false},"rules":[{"http":{"paths":[{"path":"/","pathType":"Prefix","backend":{"service":{"name":"nexus3-sonatype-nexus","port":{"number":8081}}}}]}}]},"serviceAccount":{"create":false}}'
           ],
         ],
       },


### PR DESCRIPTION
Remove EOL EKS version 1.18-1.19
Upgrade ALB ingress controller to 2.4.1
Upgrade Nexus chart to 5.4.0
Modify ALB rules format to adapt to networking API v1
unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.