### PR TITLE
fix(deps): Updating chart repo to one that is actively maintained.

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Also this application uses below open source projects,
 
 - [Nexus OSS](https://github.com/sonatype/nexus-public)
 - [travelaudience/kubernetes-nexus](https://github.com/travelaudience/kubernetes-nexus/) 
-- Nexus3 Helm chart in [Oteemo/charts](https://github.com/Oteemo/charts)
+- Nexus3 Helm chart in [da-code-a/noteemo-charts](https://github.com/da-code-a)
 - [AWS Load Balancer Controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller)
 - [EKS Charts](https://github.com/aws/eks-charts)
 - [aws-efs-csi-driver](https://github.com/kubernetes-sigs/aws-efs-csi-driver)

--- a/src/lib/sonatype-nexus3-stack.ts
+++ b/src/lib/sonatype-nexus3-stack.ts
@@ -33,7 +33,7 @@ export class SonatypeNexus3Stack extends cdk.Stack {
           nexusProxy: 'quay.io/travelaudience/docker-nexus-proxy',
           albHelmChartRepo: 'https://aws.github.io/eks-charts',
           efsCSIHelmChartRepo: 'https://kubernetes-sigs.github.io/aws-efs-csi-driver/',
-          nexusHelmChartRepo: 'https://oteemo.github.io/charts/',
+          nexusHelmChartRepo: 'https://da-code-a.github.io/noteemo-charts/',
         },
         'aws-cn': {
           nexus: '048912060910.dkr.ecr.cn-northwest-1.amazonaws.com.cn/quay/travelaudience/docker-nexus',
@@ -672,7 +672,7 @@ export class SonatypeNexus3Stack extends cdk.Stack {
     }
 
     const enableAutoConfigured: boolean = this.node.tryGetContext('enableAutoConfigured') || false;
-    const nexus3ChartVersion = '5.4.0';
+    const nexus3ChartVersion = '6.0.0';
 
     const nexus3PurgeFunc = new lambda_python.PythonFunction(this, 'Nexus3Purge', {
       description: 'Func purges the resources(such as pvc) left after deleting Nexus3 helm chart',


### PR DESCRIPTION
*Description of changes:*

The Oteemo Charts repository has been deprecated and is no longer maintained. I have created a fork that will be actively maintained and have switched the Helm repository pointed at here to the new one. Additionally, I changed the default chart version to 6.0.0 so that Nexus will be updated to 3.42.0.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.